### PR TITLE
[CON-2792] It would appear that since the deployment of the automated…

### DIFF
--- a/src/SFA.DAS.Forecasting.Jobs.Application.UnitTests/Handlers/WhenHandlingEmployerLevyRefreshComplete.cs
+++ b/src/SFA.DAS.Forecasting.Jobs.Application.UnitTests/Handlers/WhenHandlingEmployerLevyRefreshComplete.cs
@@ -60,10 +60,10 @@ namespace SFA.DAS.Forecasting.Jobs.Application.UnitTests
 
         [Test]
         [Category("UnitTest")]
-        [TestCase(4, 2019, 1)]
-        [TestCase(5, 2019, 2)]
-        [TestCase(1, 2020, 10)]
-        [TestCase(4, 2020, 1)]
+        [TestCase(4, 2019, 12)]
+        [TestCase(5, 2019, 1)]
+        [TestCase(1, 2020, 9)]
+        [TestCase(4, 2020, 12)]
 
         public async Task If_No_PeriodMonth_Should_Calculate_Today_Month(int currentMonth, int currentYear, short expectedPeriodMonth)
         {
@@ -90,10 +90,10 @@ namespace SFA.DAS.Forecasting.Jobs.Application.UnitTests
 
         [Test]
         [Category("UnitTest")]
-        [TestCase(4, 2019, "19-20")]
+        [TestCase(4, 2019, "18-19")]
         [TestCase(5, 2019, "19-20")]
         [TestCase(1, 2020, "19-20")]
-        [TestCase(4, 2020, "20-21")]
+        [TestCase(4, 2020, "19-20")]
 
         public async Task If_No_PeriodYear_Should_Calculate_Today_Year(int currentMonth, int currentYear, string expectedPeriodYear)
         {

--- a/src/SFA.DAS.Forecasting.Jobs.Application/Triggers/Handlers/LevyCompleteTriggerHandler.cs
+++ b/src/SFA.DAS.Forecasting.Jobs.Application/Triggers/Handlers/LevyCompleteTriggerHandler.cs
@@ -36,13 +36,13 @@ namespace SFA.DAS.Forecasting.Jobs.Application.Triggers.Handlers
         private string GetTodayPeriodYear(DateTime eventCreatedDate)
         {
             var twoDigitYear = int.Parse(eventCreatedDate.ToString("yy"));
-            return eventCreatedDate.Month < 4 ? $"{twoDigitYear - 1}-{twoDigitYear}" : $"{twoDigitYear}-{twoDigitYear + 1}";
+            return eventCreatedDate.Month <= 4 ? $"{twoDigitYear - 1}-{twoDigitYear}" : $"{twoDigitYear}-{twoDigitYear + 1}";
         }
 
         private short GetTodayPeriodMonth(DateTime eventCreatedDate)
         {
             var month = eventCreatedDate.Month;
-            return (short)(month >= 4 ? month - 3 : month + 9);
+            return (short)(month >= 5 ? month - 4 : month + 8);
         }
     }
 }


### PR DESCRIPTION
… trigger, the levyDeclarationEvent month and year mapping has been incorrect. This means that when it triggers the forecast it tries to pull a month of levy declarations which don't yet exists.